### PR TITLE
Fix: Add Float16 to dtype rejection test

### DIFF
--- a/tests/test_dtype_rejection.cpp
+++ b/tests/test_dtype_rejection.cpp
@@ -39,6 +39,7 @@ int main()
         { GDT_UInt16,  "uint16"  },
         { GDT_Int16,   "int16"   },
         { GDT_Int32,   "int32"   },
+        { GDT_Float16, "float16" },
         { GDT_Float64, "float64" },
     };
 


### PR DESCRIPTION
Ensure Float16 is rejected along with unsupported dtypes